### PR TITLE
Add ps4 controller

### DIFF
--- a/gamecontroller.js
+++ b/gamecontroller.js
@@ -61,13 +61,22 @@ GameController.prototype = {
         let sp = s.split(":");
 
         if (sp[0] === 'axis') {
+          if(sp[2] === 'X') {
+            let Ykey = sp[0] + ':' + sp[1] + ':Y';
 
-          let Ykey = sp[0] + ':' + sp[1] + ':Y';
+            if (ns !== os || newState[Ykey] !== oldState[Ykey]) {
+              pass.x = ns;
+              pass.y = newState[Ykey];
+              self.emit(sp[1] + ':move', pass);
+            }
+          } else if(sp[2] === 'Y') {
+            let Xkey = sp[0] + ':' + sp[1] + ':X';
 
-          if (sp[2] === 'X' && (ns !== os || newState[Ykey] !== oldState[Ykey])) {
-            pass.x = ns;
-            pass.y = newState[Ykey];
-            self.emit(sp[1] + ':move', pass);
+            if (ns !== os || newState[Xkey] !== oldState[Xkey]) {
+              pass.x = newState[Xkey];
+              pass.y = ns;
+              self.emit(sp[1] + ':move', pass);
+            }
           }
         } else if (os !== ns) {
 

--- a/lib/vendors.js
+++ b/lib/vendors.js
@@ -316,5 +316,122 @@ module.exports = {
     "setLED": function(led, val) {
       
     }
+  },
+  "ps4-gen2": { //Written to work over USB connection, limited Bluetooth support. productId for gen1: 1476, should work the same
+    "vendorId": 1356,
+    "productId": 2508,
+    "state": {
+      "axis:LY": 0,
+      "axis:LX": 0,
+      "axis:RY": 0,
+      "axis:RX": 0,
+      
+      "button:Up": 0,
+      "button:UpRight": 0,
+      "button:Right": 0,
+      "button:DownRight": 0,
+      "button:Down": 0,
+      "button:DownLeft": 0,
+      "button:Left": 0,
+      "button:UpLeft": 0,
+
+      "button:S": 0,
+      "button:X": 0,
+      "button:O": 0,
+      "button:T": 0,
+      
+      "button:L1": 0,
+      "button:R1": 0,
+      "button:L2": 0,
+      "button:R2": 0,
+
+      "button:Share": 0,
+      "button:Options": 0,
+
+      "button:L3": 0,
+      "button:R3": 0,
+
+      "button:PS": 0,
+      "button:Touchpad": 0
+    },
+    "prev": {// Simple copy of state
+      "axis:LY": 0,
+      "axis:LX": 0,
+      "axis:RY": 0,
+      "axis:RX": 0,
+      
+      "button:Up": 0,
+      "button:UpRight": 0,
+      "button:Right": 0,
+      "button:DownRight": 0,
+      "button:Down": 0,
+      "button:DownLeft": 0,
+      "button:Left": 0,
+      "button:UpLeft": 0,
+
+      "button:S": 0,
+      "button:X": 0,
+      "button:O": 0,
+      "button:T": 0,
+      
+      "button:L1": 0,
+      "button:R1": 0,
+      "button:L2": 0,
+      "button:R2": 0,
+
+      "button:Share": 0,
+      "button:Options": 0,
+
+      "button:L3": 0,
+      "button:R3": 0,
+
+      "button:PS": 0,
+      "button:Touchpad": 0
+    },
+    "update": function(data) {
+      
+      var state = this.state;
+      
+      state['axis:JOYL:Y'] = data[1];
+      state['axis:JOYL:X'] = data[2];
+      state['axis:JOYR:Y'] = data[3];
+      state['axis:JOYR:X'] = data[4];
+
+      state['button:Up'] = +((data[5] & 0x0F) === 0);
+      state['button:UpRight'] = +((data[5] & 0x0F) === 1);
+      state['button:Right'] = +((data[5] & 0x0F) === 2);
+      state['button:DownRight'] = +((data[5] & 0x0F) === 3);
+      state['button:Down'] = +((data[5] & 0x0F) === 4);
+      state['button:DownLeft'] = +((data[5] & 0x0F) === 5);
+      state['button:Left'] = +((data[5] & 0x0F) === 6);
+      state['button:UpLeft'] = +((data[5] & 0x0F) === 7);
+      
+      state['button:S'] = data[5] >> 4 & 1;
+      state['button:X'] = data[5] >> 5 & 1;
+      state['button:O'] = data[5] >> 6 & 1;
+      state['button:T'] = data[5] >> 7 & 1;
+      
+      state['button:L1'] = data[6] >> 0 & 1;
+      state['button:R1'] = data[6] >> 1 & 1;
+      state['button:L2'] = data[6] >> 2 & 1;
+      state['button:R2'] = data[6] >> 3 & 1;
+      
+      state['button:Share'] = data[6] >> 4 & 1;
+      state['button:Options'] = data[6] >> 5 & 1;
+
+      state['button:L3'] = data[6] >> 6 & 1;
+      state['button:R3'] = data[6] >> 7 & 1;
+
+      state['button:PS'] = data[7] >> 0 & 1;
+      state['button:Touchpad'] = data[7] >> 1 & 1;
+
+      return state;
+    },
+    "setRumble": function() {
+      
+    },
+    "setLED": function(led, val) {
+      
+    }
   }
 };


### PR DESCRIPTION
Added support for PS4 DualShock Gen 2 controllers. Should work with Gen 1, however the productId will need to be changed. Supports all button presses and both joysticks.
Does not yet support L2/R2 pressure, accelerometer/gyroscope readings, or touch-pad touches.